### PR TITLE
#1 use ISSUER_SEPARATOR

### DIFF
--- a/iotics/lib/identity/api/advanced_api.py
+++ b/iotics/lib/identity/api/advanced_api.py
@@ -2,6 +2,7 @@
 import secrets
 from typing import Callable, Optional, Tuple
 
+from iotics.lib.identity.const import ISSUER_SEPARATOR
 from iotics.lib.identity.api.advanced_api_keys import RegisterAuthDelegPublicDocKeysApi, RegisterAuthPublicDocKeysApi, \
     RegisterCtrlDelegPublicDocKeysApi, RegisterPublicDocKeysApi
 from iotics.lib.identity.const import DEFAULT_TOKEN_START_OFFSET_SECONDS
@@ -304,7 +305,7 @@ class AdvancedIdentityRegisterApi:
         """
         key_pair = KeyPairSecretsHelper.get_key_pair(key_pair_secrets)
         did = AdvancedIdentityLocalApi.create_identifier(key_pair.public_bytes)
-        name = name or f'#{purpose}-0'
+        name = name or f'{ISSUER_SEPARATOR}{purpose}-0'
         issuer = Issuer.build(did, name)
         if override_doc:
             self.register_new_doc(key_pair_secrets, issuer, purpose)

--- a/iotics/lib/identity/crypto/issuer.py
+++ b/iotics/lib/identity/crypto/issuer.py
@@ -41,8 +41,8 @@ class Issuer:
         parts = issuer_string.split(ISSUER_SEPARATOR)
         if len(parts) != 2:
             raise IdentityValidationError(
-                f'Invalid issuer string {issuer_string} should be of the form of [did]#[name]')
-        return Issuer.build(parts[0], f'#{parts[1]}')
+                f'Invalid issuer string {issuer_string} should be of the form of [did]{ISSUER_SEPARATOR}[name]')
+        return Issuer.build(parts[0], f'{ISSUER_SEPARATOR}{parts[1]}')
 
     def __str__(self) -> str:
         return f'{self.did}{self.name}'

--- a/tests/behaviour/common.py
+++ b/tests/behaviour/common.py
@@ -1,3 +1,4 @@
+from iotics.lib.identity.const import ISSUER_SEPARATOR
 from typing import Dict, Optional
 
 import pytest
@@ -21,7 +22,7 @@ class RESTRequesterTest(RESTResolverRequester):
         self.doc_tokens = doc_tokens or {}
 
     def get_token(self, doc_id: str) -> str:
-        token = self.doc_tokens.get(doc_id.split('#')[0])
+        token = self.doc_tokens.get(doc_id.split(ISSUER_SEPARATOR)[0])
         if not token:
             raise IdentityResolverHttpDocNotFoundError(doc_id)
         return token

--- a/tests/unit/iotics/lib/identity/fake.py
+++ b/tests/unit/iotics/lib/identity/fake.py
@@ -1,5 +1,6 @@
 # Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
 
+from iotics.lib.identity.const import ISSUER_SEPARATOR
 from typing import Dict
 
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -15,7 +16,7 @@ class ResolverClientTest(ResolverClient):
         self.docs = docs or {}
 
     def get_document(self, doc_id: str) -> RegisterDocument:
-        doc = self.docs.get(doc_id.split('#')[0])
+        doc = self.docs.get(doc_id.split(ISSUER_SEPARATOR)[0])
         if not doc:
             raise IdentityResolverDocNotFoundError(doc_id)
         return doc

--- a/tests/unit/iotics/lib/identity/fake.py
+++ b/tests/unit/iotics/lib/identity/fake.py
@@ -1,10 +1,10 @@
 # Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
 
-from iotics.lib.identity.const import ISSUER_SEPARATOR
 from typing import Dict
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
+from iotics.lib.identity.const import ISSUER_SEPARATOR
 from iotics.lib.identity.crypto.issuer import Issuer
 from iotics.lib.identity.error import IdentityResolverDocNotFoundError
 from iotics.lib.identity.register.document import RegisterDocument


### PR DESCRIPTION
Replaced hard-coded `#` with `ISSUER_SEPARATOR`.

I've left `#` hard-coded in most of the test files, as it seemed right to leave it there and "keep it simple".