### PR TITLE
EI-1122 - Introduce delegation proof type

### DIFF
--- a/iotics/lib/identity/api/advanced_api_proof.py
+++ b/iotics/lib/identity/api/advanced_api_proof.py
@@ -1,0 +1,59 @@
+# Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
+from dataclasses import dataclass
+from typing import Union
+
+from iotics.lib.identity.crypto.proof import Issuer, KeyPairSecrets, Proof
+from iotics.lib.identity.register.keys import DelegationProofType
+
+
+@dataclass(frozen=True)
+class APIProof:
+    issuer: Issuer
+    content: bytes
+    signature: str
+
+    @property
+    def p_type(self) -> DelegationProofType:
+        return DelegationProofType.DID
+
+    @staticmethod
+    def build(key_pair: KeyPairSecrets, issuer: Issuer, content: bytes) -> 'APIProof':
+        proof = Proof.build(key_pair, issuer, content)
+        return APIProof(proof.issuer, proof.content, proof.signature)
+
+
+@dataclass(frozen=True)
+class APIDidDelegationProof(APIProof):
+
+    @property
+    def p_type(self) -> DelegationProofType:
+        return DelegationProofType.DID
+
+    # pylint: disable=arguments-differ
+    @staticmethod
+    def build(key_pair: KeyPairSecrets, issuer: Issuer, did: str) -> 'APIDidDelegationProof':
+        proof = APIProof.build(key_pair, issuer, did.encode())
+        return APIDidDelegationProof(proof.issuer, proof.content, proof.signature)
+
+
+@dataclass(frozen=True)
+class APIGenericDelegationProof(APIProof):
+
+    @property
+    def p_type(self) -> DelegationProofType:
+        return DelegationProofType.GENERIC
+
+    # pylint: disable=arguments-differ
+    @staticmethod
+    def build(key_pair: KeyPairSecrets, issuer: Issuer) -> 'APIGenericDelegationProof':
+        proof = APIProof.build(key_pair, issuer, b'')
+        return APIGenericDelegationProof(proof.issuer, proof.content, proof.signature)
+
+
+def get_proof_type(proof: Union[Proof, APIProof]) -> DelegationProofType:
+    """
+    Backward compatibility function to allow legacy Proof usage and new API Delegation Proof usage
+    :param proof: a Proof or an API Delegation Proof
+    :return: the proof type or the default proof type if not present
+    """
+    return getattr(proof, 'p_type', DelegationProofType.DID)

--- a/tests/behaviour/features/advanced_identity_api.feature
+++ b/tests/behaviour/features/advanced_identity_api.feature
@@ -58,8 +58,13 @@ Feature: Advanced Identity API
     When the DelegatingRId delegates control to the DelegatedRId
     Then the DelegatedRId is allowed for control on the document owned by the DelegatingRId
 
-  Scenario: Add a control delegation proof (created by an other registered identity) to a document
-    Given a DelegatingRId owning a document and a delegation proof created by a DelegatedRId
+  Scenario: Add a control delegation did proof (created by an other registered identity) to a document
+    Given a DelegatingRId owning a document and a delegation did proof created by a DelegatedRId
+    When I add the control delegation proof to the document owned by the DelegatingRId
+    Then the DelegatedRId is allowed for control on the document owned by the DelegatingRId
+
+  Scenario: Add a control delegation generic proof (created by an other registered identity) to a document
+    Given a DelegatingRId owning a document and a delegation generic proof created by a DelegatedRId
     When I add the control delegation proof to the document owned by the DelegatingRId
     Then the DelegatedRId is allowed for control on the document owned by the DelegatingRId
 
@@ -78,8 +83,13 @@ Feature: Advanced Identity API
     When the DelegatingRId delegates authentication to the DelegatedRId
     Then the DelegatedRId is allowed for authentication on the document owned by the DelegatingRId
 
-  Scenario: Add an authentication delegation proof (created by an other registered identity) to a document
-    Given a DelegatingRId owning a document and a delegation proof created by a DelegatedRId
+  Scenario: Add an authentication delegation did proof (created by an other registered identity) to a document
+    Given a DelegatingRId owning a document and a delegation did proof created by a DelegatedRId
+    When I add the authentication delegation proof to the document owned by the DelegatingRId
+    Then the DelegatedRId is allowed for authentication on the document owned by the DelegatingRId
+
+  Scenario: Add an authentication delegation generic proof (created by an other registered identity) to a document
+    Given a DelegatingRId owning a document and a delegation generic proof created by a DelegatedRId
     When I add the authentication delegation proof to the document owned by the DelegatingRId
     Then the DelegatedRId is allowed for authentication on the document owned by the DelegatingRId
 

--- a/tests/behaviour/test_advanced_identity.py
+++ b/tests/behaviour/test_advanced_identity.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_bdd import given, scenario, then, when
 
 from iotics.lib.identity import AdvancedIdentityLocalApi, AdvancedIdentityRegisterApi, DIDType, IdentityApi, Issuer, \
-    KeyPairSecretsHelper, Proof, RegisteredIdentity, ResolverSerializer, RESTResolverClient
+    KeyPairSecretsHelper, RegisteredIdentity, ResolverSerializer, RESTResolverClient, APIProof
 from tests.behaviour.common import assert_owner_is_allowed, assert_owner_key, assert_owner_not_allowed_anymore, \
     assert_owner_pub_key_exist, get_allowed_for_auth_and_control_error, get_allowed_for_auth_error, \
     get_allowed_for_control_error, get_secrets_by_type, RESTRequesterTest
@@ -97,7 +97,7 @@ class RegisteredIdentitiesExistingRegDelegProofCtx(RegisteredIdentitiesForDelegC
 
 @dataclass(frozen=True)
 class RegisteredIdentitiesAddDelegProofCtx(RegisteredIdentitiesExistingRegDelegProofCtx):
-    proof: Proof
+    proof: APIProof
 
 
 @dataclass(frozen=True)
@@ -214,13 +214,31 @@ def given_a_register_identity_ida_owning_the_delegating_doc_and_a_register_ident
     ))
 
 
-@given('a DelegatingRId owning a document and a delegation proof created by a DelegatedRId', target_fixture='context')
+@given('a DelegatingRId owning a document and a delegation did proof created by a DelegatedRId',
+       target_fixture='context')
 def given_a_reg_identity_ida_owning_the_delegating_doc_and_a_delegation_proof_created_by_an_other_registered_identity():
     delegating_id = get_registered_identity('#Delegating')
     delegated_id = get_registered_identity('#Delegated')
     subject_doc = ADVANCED_API.get_register_document(delegated_id.registered_identity.did)
     subject_issuer, delegation_proof = AdvancedIdentityLocalApi.create_delegation_proof(
         delegating_issuer=delegating_id.registered_identity.issuer,
+        subject_doc=subject_doc,
+        subject_secrets=delegated_id.registered_identity.key_pair_secrets)
+    return get_new_context(RegisteredIdentitiesAddDelegProofCtx(
+        delegating_id=delegating_id.registered_identity,
+        delegated_id=delegated_id.registered_identity,
+        proof=delegation_proof,
+        delegation_name='#DelegFromPRoof'
+    ))
+
+
+@given('a DelegatingRId owning a document and a delegation generic proof created by a DelegatedRId',
+       target_fixture='context')
+def given_a_reg_identity_ida_owning_the_delegating_doc_and_a_delegation_reusable_proof_created_by_an_other_reg_id():
+    delegating_id = get_registered_identity('#Delegating')
+    delegated_id = get_registered_identity('#Delegated')
+    subject_doc = ADVANCED_API.get_register_document(delegated_id.registered_identity.did)
+    subject_issuer, delegation_proof = AdvancedIdentityLocalApi.create_generic_delegation_proof(
         subject_doc=subject_doc,
         subject_secrets=delegated_id.registered_identity.key_pair_secrets)
     return get_new_context(RegisteredIdentitiesAddDelegProofCtx(
@@ -896,9 +914,16 @@ def test_add_a_control_delegation_between_2_existing_registered_identities():
 
 
 @scenario('advanced_identity_api.feature',
-          'Add a control delegation proof (created by an other registered identity) to a document',
+          'Add a control delegation did proof (created by an other registered identity) to a document',
           features_base_dir=FEATURES)
 def test_add_a_control_delegation_proof_from_an_other_registered_identity_to_a_document():
+    pass
+
+
+@scenario('advanced_identity_api.feature',
+          'Add a control delegation generic proof (created by an other registered identity) to a document',
+          features_base_dir=FEATURES)
+def test_add_a_control_delegation_reusable_proof_from_an_other_registered_identity_to_a_document():
     pass
 
 
@@ -920,9 +945,16 @@ def test_add_an_authentication_delegation_between_2_existing_registered_identiti
 
 
 @scenario('advanced_identity_api.feature',
-          'Add an authentication delegation proof (created by an other registered identity) to a document',
+          'Add an authentication delegation did proof (created by an other registered identity) to a document',
           features_base_dir=FEATURES)
 def test_add_an_authentication_delegation_proof_from_an_other_registered_identity_to_a_document():
+    pass
+
+
+@scenario('advanced_identity_api.feature',
+          'Add an authentication delegation generic proof (created by an other registered identity) to a document',
+          features_base_dir=FEATURES)
+def test_add_an_authentication_delegation_reusable_proof_from_an_other_registered_identity_to_a_document():
     pass
 
 

--- a/tests/unit/iotics/lib/identity/api/test_advanced_api_proof.py
+++ b/tests/unit/iotics/lib/identity/api/test_advanced_api_proof.py
@@ -1,0 +1,55 @@
+# Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
+
+from iotics.lib.identity import APIDidDelegationProof, APIGenericDelegationProof, APIProof, get_proof_type, Proof
+from iotics.lib.identity.register.keys import DelegationProofType
+
+
+def test_can_build_api_proof(valid_issuer, valid_key_pair_secrets):
+    content = b"some content"
+    proof = APIProof.build(
+        valid_key_pair_secrets,
+        valid_issuer,
+        content
+    )
+    assert proof.signature, 'the proof should have a not empty signature'
+    assert proof.issuer == valid_issuer
+    assert proof.content == content
+    assert proof.p_type == DelegationProofType.DID
+
+
+def test_can_build_api_did_delegation_proof(doc_did, valid_issuer, valid_key_pair_secrets):
+    proof = APIDidDelegationProof.build(
+        valid_key_pair_secrets,
+        valid_issuer,
+        doc_did
+    )
+    assert proof.signature, 'the proof should have a not empty signature'
+    assert proof.issuer == valid_issuer
+    assert proof.content == doc_did.encode()
+    assert proof.p_type == DelegationProofType.DID
+
+
+def test_can_build_api_generic_delegation_proof(valid_issuer, valid_key_pair_secrets):
+    proof = APIGenericDelegationProof.build(
+        valid_key_pair_secrets,
+        valid_issuer
+    )
+    assert proof.signature, 'the proof should have a not empty signature'
+    assert proof.issuer == valid_issuer
+    assert proof.content == b''
+    assert proof.p_type == DelegationProofType.GENERIC
+
+
+def test_get_proof_type_support_legacy_proof(valid_issuer, valid_key_pair_secrets):
+    proof = Proof.build(valid_key_pair_secrets, valid_issuer, b'content')
+    assert get_proof_type(proof) == DelegationProofType.DID
+
+
+def test_can_get_proof_type_from_api_did_delegation_proof(doc_did, valid_issuer, valid_key_pair_secrets):
+    proof = APIDidDelegationProof.build(valid_key_pair_secrets, valid_issuer, doc_did)
+    assert get_proof_type(proof) == DelegationProofType.DID
+
+
+def test_can_get_proof_type_from_api_generic_delegation_proof(valid_issuer, valid_key_pair_secrets):
+    proof = APIGenericDelegationProof.build(valid_key_pair_secrets, valid_issuer)
+    assert get_proof_type(proof) == DelegationProofType.GENERIC

--- a/tests/unit/iotics/lib/identity/validation/helper.py
+++ b/tests/unit/iotics/lib/identity/validation/helper.py
@@ -1,9 +1,10 @@
 # Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
 
-from typing import Callable
+from typing import Callable, Tuple
 
 import base58
 
+from iotics.lib.identity import DelegationProofType, RegisterDocument, APIProof
 from iotics.lib.identity.api.advanced_api import AdvancedIdentityLocalApi
 from iotics.lib.identity.crypto.identity import make_identifier
 from iotics.lib.identity.crypto.issuer import Issuer
@@ -26,24 +27,33 @@ def is_validator_run_success(validator: Callable, *args, **kwargs):
     return True
 
 
-def get_delegation_proof(issuer: Issuer, key_pair_secrets: KeyPairSecrets, delegating_doc_id: str) -> Proof:
-    return Proof.build(key_pair_secrets, issuer, content=delegating_doc_id.encode())
+def get_delegation_proof(issuer: Issuer, key_pair_secrets: KeyPairSecrets, delegating_doc_id: str) -> APIProof:
+    return APIProof.build(key_pair_secrets, issuer, content=delegating_doc_id.encode())
 
 
-def get_delegation_register_proof(subject_key_pair_secrets: KeyPairSecrets, delegating_doc_id: str,
+def get_delegation_register_proof(subject_key_pair_secrets: KeyPairSecrets,
                                   subject_issuer: Issuer,
+                                  content: bytes,
+                                  p_type: DelegationProofType,
                                   deleg_key_name='#DelegKey') -> RegisterDelegationProof:
-    proof = Proof.build(subject_key_pair_secrets, subject_issuer, content=delegating_doc_id.encode())
+    proof = Proof.build(subject_key_pair_secrets, subject_issuer, content=content)
 
     return RegisterDelegationProof.build(deleg_key_name,
                                          controller=subject_issuer,
                                          proof=proof.signature,
+                                         p_type=p_type,
                                          revoked=False)
 
 
 def get_valid_document(seed: bytes, issuer_name: str, controller: Issuer = None):
     secrets = KeyPairSecrets.build(seed, 'iotics/0/something/twin')
     return get_valid_document_from_secret(secrets, issuer_name, controller)
+
+
+def get_new_document(issuer_name: str) -> Tuple[KeyPairSecrets, Issuer, RegisterDocument]:
+    secrets = KeyPairSecrets.build(new_seed(), 'iotics/0/something')
+    doc = get_valid_document_from_secret(secrets, issuer_name)
+    return secrets, Issuer.build(doc.did, issuer_name), doc
 
 
 def get_valid_document_from_secret(secrets: KeyPairSecrets, issuer_name: str, controller: Issuer = None):
@@ -69,7 +79,8 @@ def get_valid_delegated_doc_and_deleg_proof(seed: bytes, issuer_name: str, deleg
     proof = Proof.build(secrets, issuer, content=doc_id.encode())
 
     deleg_key = get_delegation_register_proof(subject_key_pair_secrets=secrets,
-                                              delegating_doc_id=delegating_doc_id,
+                                              content=delegating_doc_id.encode(),
+                                              p_type=DelegationProofType.DID,
                                               subject_issuer=Issuer.build(doc_id, issuer_name),
                                               deleg_key_name=deleg_name)
     delegated_doc = RegisterDocumentBuilder() \


### PR DESCRIPTION
First commit:
* create_reusable_delegation_proof new helper
* allow for reusable proof usage in delegate_authentication and delegate_control helpers
* validate proof: add fallback on reusable proof validation

Second commit after catch-up for new strategy: introduce delegation proof type:
* New Delegation Proof Type {DID, GENERIC}
* New API Proof objects: APIProof, APIDidDelegationProof, APIGenericDelegationProof used in advanced api
  (decouple api from crypto proof, deal with deleagtion proof type and content, backward compatible)
* New Advanced API helpers to create generic proof and allow delegation with generic proof
* New validation mode according to the proof type
* New Regisered document delegation proof type serialization
