### PR TITLE
fix: EI-2318 | bump dependencies

### DIFF
--- a/.github/workflows/iotics-identity.yml
+++ b/.github/workflows/iotics-identity.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -43,13 +43,13 @@ jobs:
     needs: validate
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel==0.36.2
+          python -m pip install --upgrade pip wheel==0.40.0
       - name: Package
         run: |
           python3 setup.py -q clean -a
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.pylint.rc
+++ b/.pylint.rc
@@ -22,7 +22,7 @@ jobs=4
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.no_self_use
 
 # Pickle collected data for later comparisons.
 persistent=no
@@ -148,12 +148,6 @@ max-line-length=120
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no
@@ -165,14 +159,8 @@ single-line-if-stmt=no
 
 [BASIC]
 
-# Naming hint for argument names
-argument-name-hint=[a-z][a-zA-Z0-9_]{1,36}_?$
-
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-zA-Z0-9_]{1,36}_?))$
-
-# Naming hint for attribute names
-attr-name-hint=((_{0,2}[a-z][a-zA-Z0-9_]{1,36}_?))$
 
 # Regular expression matching correct attribute names
 attr-rgx=((_{0,2}[a-z][a-zA-Z0-9_]{1,36}_?))$
@@ -180,20 +168,11 @@ attr-rgx=((_{0,2}[a-z][a-zA-Z0-9_]{1,36}_?))$
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
 
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{1,36}|(__.*__))$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{1,36}|(__.*__))$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -201,9 +180,6 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
-
-# Naming hint for function names
-function-name-hint=((_{0,2}[a-z][a-zA-Z0-9_]{2,36}))$
 
 # Regular expression matching correct function names
 function-rgx=((_{0,2}[a-z][a-zA-Z0-9_]{2,100}))$
@@ -215,20 +191,11 @@ good-names=i,j,k,ex,Run,_,log,n3,m,s,p,o
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for method names
-method-name-hint=((_{0,2}[a-z][a-zA-Z0-9_]{1,36}(__)?))$
-
 # Regular expression matching correct method names
 method-rgx=((_{0,2}[a-z][a-zA-Z0-9_]{1,100}(__)?))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -244,9 +211,6 @@ no-docstring-rgx=^_
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
 property-classes=abc.abstractproperty
-
-# Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
@@ -438,4 +402,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/iotics/lib/identity/api/advanced_api.py
+++ b/iotics/lib/identity/api/advanced_api.py
@@ -716,7 +716,7 @@ class AdvancedIdentityRegisterApi:
             subject_issuer, proof = AdvancedIdentityLocalApi.create_generic_delegation_proof(subject_doc,
                                                                                              subject_secrets)
         else:
-            subject_issuer, proof = AdvancedIdentityLocalApi.create_delegation_proof(delegating_issuer,
+            subject_issuer, proof = AdvancedIdentityLocalApi.create_delegation_proof(delegating_issuer,  # type: ignore
                                                                                      subject_doc,
                                                                                      subject_secrets)
 

--- a/iotics/lib/identity/api/advanced_api_proof.py
+++ b/iotics/lib/identity/api/advanced_api_proof.py
@@ -31,7 +31,7 @@ class APIDidDelegationProof(APIProof):
 
     # pylint: disable=arguments-differ
     @staticmethod
-    def build(key_pair: KeyPairSecrets, issuer: Issuer, did: str) -> 'APIDidDelegationProof':
+    def build(key_pair: KeyPairSecrets, issuer: Issuer, did: str) -> 'APIDidDelegationProof':  # type: ignore
         proof = APIProof.build(key_pair, issuer, did.encode())
         return APIDidDelegationProof(proof.issuer, proof.content, proof.signature)
 
@@ -45,7 +45,7 @@ class APIGenericDelegationProof(APIProof):
 
     # pylint: disable=arguments-differ
     @staticmethod
-    def build(key_pair: KeyPairSecrets, issuer: Issuer) -> 'APIGenericDelegationProof':
+    def build(key_pair: KeyPairSecrets, issuer: Issuer) -> 'APIGenericDelegationProof':  # type: ignore
         proof = APIProof.build(key_pair, issuer, b'')
         return APIGenericDelegationProof(proof.issuer, proof.content, proof.signature)
 

--- a/iotics/lib/identity/api/advanced_api_proof.py
+++ b/iotics/lib/identity/api/advanced_api_proof.py
@@ -29,7 +29,7 @@ class APIDidDelegationProof(APIProof):
     def p_type(self) -> DelegationProofType:
         return DelegationProofType.DID
 
-    # pylint: disable=arguments-differ
+    # pylint: disable=arguments-renamed
     @staticmethod
     def build(key_pair: KeyPairSecrets, issuer: Issuer, did: str) -> 'APIDidDelegationProof':  # type: ignore
         proof = APIProof.build(key_pair, issuer, did.encode())

--- a/iotics/lib/identity/crypto/jwt.py
+++ b/iotics/lib/identity/crypto/jwt.py
@@ -47,7 +47,7 @@ class JwtTokenHelper:
         try:
             key = KeysHelper.get_public_ECDSA_from_base58(public_base58)
             return jwt.decode(token, key, audience=audience, algorithms=[TOKEN_ALGORITHM],  # type: ignore
-                              verify=True, options={'verify_signature': True})
+                              verify=True, options={'verify_signature': True, 'verify_aud': bool(audience)})
         except jwt.exceptions.InvalidSignatureError as err:
             raise IdentityValidationError(f'Invalid token signature: \'{err}\'') from err
         except jwt.exceptions.ExpiredSignatureError as err:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-complexity = 15
 
 [metadata]
 name = iotics-identity
-version = 1.0.4
+version = 1.0.5
 description = Iotics DID specification Python library
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ lint =
     pylint==2.17.4
     pylint-quotes==0.2.3
     mypy==1.4.1
+    types-requests
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [tool:pytest]
 testpaths = tests
 
+[mypy]
+strict_optional = false
+
 [flake8]
 exclude =
     env
@@ -45,28 +48,28 @@ zip_safe = True
 include_package_data = True
 packages = find:
 install_requires =
-    requests>=2.22.0
-    base58==2.1.0
-    PyJWT==2.0.1
-    mnemonic==0.19
-    cryptography>=3.4.7,<4
+    requests>=2.31.0
+    base58==2.1.1
+    PyJWT==2.7.0
+    mnemonic==0.20
+    cryptography>=41.0.2,<42
 
 [options.extras_require]
 dev =
-    tox==3.20.0
+    tox==4.6.4
 
 test =
-    pytest==6.2.4
-    pytest-bdd==4.0.2
-    pytest-cov==2.11.1
-    pytest-html==3.1.1
-    requests-mock==1.9.2
+    pytest==7.4.0
+    pytest-bdd==6.1.1
+    pytest-cov==4.1.0
+    pytest-html==3.2.0
+    requests-mock==1.11.0
 
 lint =
-    flake8==3.9.2
-    pylint==2.8.2
-    pylint-quotes==0.2.1
-    mypy==0.812
+    flake8==6.0.0
+    pylint==2.17.4
+    pylint-quotes==0.2.3
+    mypy==1.4.1
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-complexity = 15
 
 [metadata]
 name = iotics-identity
-version = 1.0.5
+version = 2.0.0
 description = Iotics DID specification Python library
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -29,7 +29,7 @@ platform = any
 
 url = https://github.com/Iotic-Labs/iotics-identity-py
 keywords = iotics, did, decentralised identity, decentralized identity, digital twin
-python_requires = >=3.7
+python_requires = >=3.8
 classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License

--- a/tests/unit/iotics/lib/identity/register/test_document.py
+++ b/tests/unit/iotics/lib/identity/register/test_document.py
@@ -70,11 +70,11 @@ def test_can_build_doc_metadata_from_dict():
     assert metadata.url == data['url']
 
 
-@pytest.mark.parametrize('invalid_input', (dict(label='a' * (DOCUMENT_MAX_LABEL_LENGTH + 1)),
-                                           dict(comment='a' * (DOCUMENT_MAX_COMMENT_LENGTH + 1)),
-                                           dict(url='a' * (DOCUMENT_MAX_URL_LENGTH + 1))))
+@pytest.mark.parametrize('invalid_input', ({'label': 'a' * (DOCUMENT_MAX_LABEL_LENGTH + 1)},
+                                           {'comment': 'a' * (DOCUMENT_MAX_COMMENT_LENGTH + 1)},
+                                           {'url': 'a' * (DOCUMENT_MAX_URL_LENGTH + 1)}))
 def test_build_doc_metadata_raises_validaion_error_in_invalid_data(invalid_input):
-    params = dict(label='a label', comment='a comment', url='http://an/url')
+    params = {'label': 'a label', 'comment': 'a comment', 'url': 'http://an/url'}
     params.update(invalid_input)
     with pytest.raises(IdentityValidationError):
         Metadata.build(**params)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     -e .[lint]
 
 commands =
-    mypy iotics
+    mypy --config-file setup.cfg iotics
 
 [testenv:pytest]
 deps =


### PR DESCRIPTION
This PR bumps the dependencies for the library to latest versions compatible with Python 3.8.
* Since default audience for a jwt is `""`, we now only verify audience when decoding token if one is provided and not an empty string. This is consistent with the [verification logic](https://github.com/jpadilla/pyjwt/blob/6db5df72d031bd49f8a25e84ccf4ec91b2d6af3b/jwt/api_jwt.py#L318)

* Drops support for Python 3.7, which is EOL.
* Pylint config changed according to removed options (see this [issue](https://github.com/pylint-dev/pylint/issues/6931#issuecomment-1153257823))
* Appropriate `type: ignore` comments to silence mypy on subclassed `build` methods
* Added mypy config `strict_optional = false` as default was changed
* Corrected `dict` calls to literals in tests (pylint check)